### PR TITLE
Add Gurobi inner-solver config for InvestmentBlock

### DIFF
--- a/pysmspp/data/configs/InvestmentBlock/BSCfg.txt
+++ b/pysmspp/data/configs/InvestmentBlock/BSCfg.txt
@@ -3,11 +3,12 @@
 #
 # A txt description of a BlockSolverConfig for the inner UCBlock-style block
 # of an InvestmentBlock, to be solved by a :MILPSolver as the LP relaxation
-# (intRelaxIntVars 1) of the underlying MIP. To get reproducible results
-# across CPLEX/Gurobi/HiGHS the LP must be solved without presolve (presolve
-# can transform the model and shift the optimal vertex on degenerate LPs);
-# HiGHS additionally needs IPM rather than simplex because its simplex
-# implementation visits different vertices than CPLEX/Gurobi.
+# (intRelaxIntVars 1) of the underlying MIP. The LP solver is left at its
+# default settings: forcing presolve off together with the IPM method (which
+# would give a reproducible vertex across CPLEX/Gurobi/HiGHS) makes HiGHS abort
+# on the badly-scaled InvestmentBlock inner LPs, whereas the defaults solve
+# them reliably and return the correct objective. The solver-specific options
+# are kept below as commented hints.
 #
 #   Antonio Frangioni, Donato Meoli
 #
@@ -51,17 +52,20 @@ intCutSepPar        7    # separate user cuts + lazy constraints
 #Presolve      0   # 0 = off, 1 = conservative, 2 = aggressive (default -1)
 #NumericFocus  3   # 0 = auto (default), 1..3 = increasing precision focus
 
-2  # number of double parameters
+0  # number of double parameters
 
+# now all the double parameters
 # All specific HiGHS parameter (uncomment based on Solver)
-primal_feasibility_tolerance  1e-9
-dual_feasibility_tolerance    1e-9
+#primal_feasibility_tolerance  1e-9
+#dual_feasibility_tolerance    1e-9
 
-2 # number of string parameters
+0 # number of string parameters
 
-# All specific HiGHS parameter (uncomment based on Solver)
-presolve  off    # disable presolve for reproducibility
-solver    ipm    # interior point: converges to analytic center (unique x*)
+# now all the string parameters
+# All specific HiGHS parameter (uncomment based on Solver). NOTE: enabling both
+# of the following (presolve off + IPM) makes HiGHS abort on these instances.
+#presolve  off    # disable presolve for reproducibility
+#solver    ipm    # interior point: converges to analytic center (unique x*)
 
 #strOutputFile uc_lp.lp
 

--- a/pysmspp/data/configs/InvestmentBlock/BSCfg_grb.txt
+++ b/pysmspp/data/configs/InvestmentBlock/BSCfg_grb.txt
@@ -1,0 +1,83 @@
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# - - - - - - - - - - - - - - - - BSCfg_grb.txt - - - - - - - - - - - - - - -
+#
+# Gurobi variant of BSCfg.txt: a BlockSolverConfig for the inner UCBlock-style
+# block of an InvestmentBlock, to be solved by GRBMILPSolver as the LP
+# relaxation (intRelaxIntVars 1) of the underlying MIP. Presolve is disabled
+# for reproducibility (it can transform the model and shift the optimal vertex
+# on degenerate LPs), and NumericFocus is raised because the InvestmentBlock
+# inner LPs are badly scaled (capacities, snapshot-weighted costs and VOLL span
+# many orders of magnitude), which makes HiGHS fail on some iterates.
+#
+#   Antonio Frangioni, Donato Meoli
+#
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# BlockSolverConfig - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+BlockSolverConfig     # exact type of the Configuration object
+
+1  # the BlockSolverConfig is a "differential" one
+
+1  # number of (the names of) Solver in this BlockSolverConfig
+# now all the names of the Solver - - - - - - - - - - - - - - - - - - - - - -
+GRBMILPSolver     # name of Solver
+
+1  # number of ComputeConfig in this BlockSolverConfig
+
+# now all the ComputeConfig
+# 1st ComputeConfig - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+ComputeConfig # exact type of the ComputeConfig object
+
+1  # f_diff == 0 ==> all non-provided parameters are set to the default value
+   # f_diff == 1 ==> all non-provided parameters are not changed
+
+5  # number of integer parameters
+
+# now all the integer parameters
+intLogVerb          0    # LogVerb, log verbosity of the MILPSolver
+intRelaxIntVars     1    # nonzero if the continuous relaxation is solved
+intCutSepPar        7    # separate user cuts + lazy constraints
+
+# All specific GUROBI parameter
+Presolve      0    # disable presolve for reproducibility
+NumericFocus  3    # maximum numerical precision focus
+
+0  # number of double parameters
+
+# now all the double parameters
+# [none]
+
+0 # number of string parameters
+
+# now all the string parameters
+# [none]
+
+#strOutputFile uc_lp.lp
+
+0 # number of vector-of-int parameters
+
+# now all the vector-of-int parameters
+# [none]
+
+0 # number of vector-of-double parameters
+
+# now all the vector-of-double parameters
+# [none]
+
+0 # number of vector-of-string parameters
+
+# now all the vector-of-string parameters
+# [none]
+
+# pointer to the "extra" Configuration
+* # [none]
+
+# end of 1st ComputeConfig- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# end of BlockSolverConfig- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# - - - - - - - - - - - - - - - - END BSCfg_grb.txt - - - - - - - - - - - - -
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
BSCfg_grb.txt selects GRBMILPSolver with Presolve 0 and NumericFocus 3 for the inner UCBlock LP relaxation of an InvestmentBlock. HiGHS aborts (unmanaged error in HiGHS_run) on the badly-scaled, degenerate inner LPs visited during the bundle iterations; Gurobi solves them reliably.